### PR TITLE
Changed toggleprivaterank

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dmypy.json
 .idea/
 
 offers.png
+
+.vscode/

--- a/commands/toggleprivaterank_command.py
+++ b/commands/toggleprivaterank_command.py
@@ -7,20 +7,20 @@ class ToggleprivaterankCommand(commands.Cog):
         self.bot = bot
 
     @commands.command()
-    async def toggleprivaterank(self, ctx):
+    async def toggleprivaterank(self, ctx, programme: str):
         user = ctx.message.author
         user_id = str(user.id)
 
         async with self.bot.db_conn.acquire() as connection:
             ranks = ranks_service.RanksService(connection)
 
-            is_private = await ranks.get_is_private(user_id)
+            is_private = await ranks.get_is_private_programme(user_id, programme)
 
             if is_private is None:
                 await ctx.send(user.mention + ' You haven\'t set your ranking number yet.')
                 return
 
-            await ranks.set_is_private(user_id, not is_private)
+            await ranks.set_is_private_programme(user_id, not is_private, programme)
 
             await ctx.send(user.mention + f' Your rank is {"no longer" if is_private else "now"} hidden from `.ranks`')
 

--- a/services/ranks_service.py
+++ b/services/ranks_service.py
@@ -71,9 +71,19 @@ class RanksService:
         is_private = await self.db_conn.fetchval('SELECT is_private FROM ranks '
                                                  'WHERE user_id = $1',
                                                  user_id)
+
+    async def get_is_private_programme(self, user_id: str, programme: str) -> bool:
+        is_private = await self.db_conn.fetchval('SELECT is_private FROM ranks '
+                                                 'WHERE user_id = $1 AND programme = $2',
+                                                 user_id, programme)
         return is_private
 
     async def set_is_private(self, user_id: str, is_private: bool):
         await self.db_conn.execute('UPDATE ranks SET is_private = $1 '
                                    'WHERE user_id = $2',
                                    is_private, user_id)
+
+    async def set_is_private_programme(self, user_id: str, is_private: bool, programme: str):
+        await self.db_conn.execute('UPDATE ranks SET is_private = $1 '
+                                   'WHERE user_id = $2 AND programme = $3',
+                                   is_private, user_id, programme)


### PR DESCRIPTION
The command now takes a ``programme`` argument and only turns that private instead of all the user's entries. Fixes [this](https://github.com/martinmladenov/RankingBot/issues/6) issue