### PR TITLE
 Use UUID in the file name when generating offer graphs to fix concurrency issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,6 @@ dmypy.json
 
 .idea/
 
-offers.png
+offers_*.png
 
 .vscode/

--- a/commands/offergraph_command.py
+++ b/commands/offergraph_command.py
@@ -47,11 +47,11 @@ class OffergraphCommand(commands.Cog):
         async with (await self.bot.get_db_conn()).acquire() as connection:
             offers = offers_service.OffersService(connection)
             try:
-                await offers.generate_graph(programmes_helper.programmes[programme], not approx, year)
+                filename = await offers.generate_graph(programmes_helper.programmes[programme], not approx, year)
             except ValueError:
                 await ctx.send('This programme was not numerus fixus in ' + str(year))
                 return
-        image = discord.File(offers_service.filename)
+        image = discord.File(filename)
         await ctx.send(file=image)
 
 

--- a/commands/offergraph_command.py
+++ b/commands/offergraph_command.py
@@ -53,6 +53,7 @@ class OffergraphCommand(commands.Cog):
                 return
         image = discord.File(filename)
         await ctx.send(file=image)
+        await offers.clean_up_file(filename)
 
 
 def setup(bot):

--- a/services/offers_service.py
+++ b/services/offers_service.py
@@ -3,6 +3,7 @@ from matplotlib import pyplot as plt, dates as mdates
 from matplotlib.ticker import MaxNLocator
 from helpers import programmes_helper
 import uuid
+import os
 
 filename_format = 'offers_%s.png'
 
@@ -14,6 +15,9 @@ class OffersService:
     async def generate_uuid(self) -> str:
         # Generate a version 1 UUID containing the current date and time
         return str(uuid.uuid1(node=1))
+
+    async def clean_up_file(self, filename: str):
+        os.remove(filename)
 
     async def generate_graph(self, programme: programmes_helper.Programme, step: bool, year: int):
         if year not in programme.places:

--- a/services/offers_service.py
+++ b/services/offers_service.py
@@ -2,13 +2,18 @@ from datetime import date, datetime, timedelta
 from matplotlib import pyplot as plt, dates as mdates
 from matplotlib.ticker import MaxNLocator
 from helpers import programmes_helper
+import uuid
 
-filename = 'offers.png'
+filename_format = 'offers_%s.png'
 
 
 class OffersService:
     def __init__(self, db_conn):
         self.db_conn = db_conn
+
+    async def generate_uuid(self) -> str:
+        # Generate a version 1 UUID containing the current date and time
+        return str(uuid.uuid1(node=1))
 
     async def generate_graph(self, programme: programmes_helper.Programme, step: bool, year: int):
         if year not in programme.places:
@@ -102,8 +107,12 @@ class OffersService:
         for label in ax.get_xaxis().get_major_ticks()[1::2]:
             label.set_visible(False)
 
+        filename = filename_format % await self.generate_uuid()
+
         plt.savefig(filename, facecolor=bg_color, dpi=200)
         plt.close()
+
+        return filename
 
     async def get_highest_ranks_with_offers(self, year):
         offers = await self.db_conn.fetch(

--- a/services/offers_service.py
+++ b/services/offers_service.py
@@ -19,7 +19,7 @@ class OffersService:
     async def clean_up_file(self, filename: str):
         os.remove(filename)
 
-    async def generate_graph(self, programme: programmes_helper.Programme, step: bool, year: int):
+    async def generate_graph(self, programme: programmes_helper.Programme, step: bool, year: int) -> str:
         if year not in programme.places:
             raise ValueError
 


### PR DESCRIPTION
Fixes #82 