### PR TITLE
Hide messages outside of bot spam

### DIFF
--- a/commands/offergraph_command.py
+++ b/commands/offergraph_command.py
@@ -48,6 +48,9 @@ class OffergraphCommand(commands.Cog):
         if year is None:
             year = constants.current_year
 
+        if not ctx.guild or 'bot' in ctx.channel.name:
+            public = True
+
         # Show "Bot is thinking" message
         await ctx.defer(hidden=not public)
 

--- a/commands/offergraph_command.py
+++ b/commands/offergraph_command.py
@@ -43,19 +43,20 @@ class OffergraphCommand(commands.Cog):
                    required=False,
                )
            ])
-    async def offergraph(self, ctx: SlashContext, programme: str, year: int = None, approx: bool = True, public: bool = False):
+    async def offergraph(self, ctx: SlashContext, programme: str, year: int = None,
+                         approx: bool = True, public: bool = False):
         if year is None:
             year = constants.current_year
 
         # Show "Bot is thinking" message
-        await ctx.defer()
+        await ctx.defer(hidden=not public)
 
         async with (await self.bot.get_db_conn()).acquire() as connection:
             offers = offers_service.OffersService(connection)
             try:
                 filename = await offers.generate_graph(programmes_helper.programmes[programme], not approx, year)
             except ValueError:
-                await ctx.send('This programme was not numerus fixus in ' + str(year))
+                await ctx.send('This programme was not numerus fixus in ' + str(year), hidden=not public)
                 return
         image = discord.File(filename)
         await ctx.send(file=image, hidden=not public)

--- a/commands/offergraph_command.py
+++ b/commands/offergraph_command.py
@@ -35,9 +35,15 @@ class OffergraphCommand(commands.Cog):
                    description='Show approximation line',
                    option_type=command_option_type.BOOLEAN,
                    required=False
+               ),
+               create_option(
+                   name='public',
+                   description='Show the result of the command to everyone',
+                   option_type=command_option_type.BOOLEAN,
+                   required=False,
                )
            ])
-    async def offergraph(self, ctx: SlashContext, programme: str, year: int = None, approx: bool = True):
+    async def offergraph(self, ctx: SlashContext, programme: str, year: int = None, approx: bool = True, public: bool = False):
         if year is None:
             year = constants.current_year
 
@@ -52,7 +58,7 @@ class OffergraphCommand(commands.Cog):
                 await ctx.send('This programme was not numerus fixus in ' + str(year))
                 return
         image = discord.File(filename)
-        await ctx.send(file=image)
+        await ctx.send(file=image, hidden=not public)
         await offers.clean_up_file(filename)
 
 

--- a/commands/offers_command.py
+++ b/commands/offers_command.py
@@ -39,6 +39,9 @@ class OffersCommand(commands.Cog):
             offers_svc = offers_service.OffersService(connection)
             offers = await offers_svc.get_highest_ranks_with_offers(year)
 
+        if not ctx.guild or 'bot' in ctx.channel.name:
+            public = True
+
         embed = discord.Embed(title=f"Highest known ranks with offers ({year})", color=0x36bee6)
 
         for offer in offers:

--- a/commands/offers_command.py
+++ b/commands/offers_command.py
@@ -23,9 +23,15 @@ class OffersCommand(commands.Cog):
                    option_type=command_option_type.INTEGER,
                    required=False,
                    choices=programmes_helper.get_year_choices()
+               ),
+               create_option(
+                   name='public',
+                   description='Show the result of the command to everyone',
+                   option_type=command_option_type.BOOLEAN,
+                   required=False,
                )
            ])
-    async def offers(self, ctx: SlashContext, year: int = None):
+    async def offers(self, ctx: SlashContext, year: int = None, public: bool = False):
         if year is None:
             year = constants.current_year
 
@@ -58,7 +64,7 @@ class OffersCommand(commands.Cog):
                               'Then, to set the date you received an offer, use `/setofferdate`.',
                         inline=False)
 
-        await ctx.send(embed=embed)
+        await ctx.send(embed=embed, hidden=not public)
 
 
 def setup(bot):

--- a/commands/ranks_command.py
+++ b/commands/ranks_command.py
@@ -23,9 +23,15 @@ class RanksCommand(commands.Cog):
                    option_type=command_option_type.INTEGER,
                    required=False,
                    choices=programmes_helper.get_year_choices()
+               ),
+               create_option(
+                   name='public',
+                   description='Show the result of the command to everyone',
+                   option_type=command_option_type.BOOLEAN,
+                   required=False,
                )
            ])
-    async def ranks(self, ctx: SlashContext, year: int = None):
+    async def ranks(self, ctx: SlashContext, year: int = None, public: bool = False):
 
         if year is None:
             year = constants.current_year
@@ -35,6 +41,8 @@ class RanksCommand(commands.Cog):
             grouped_ranks = await ranks.get_top_ranks(year)
 
         is_bot_channel = not ctx.guild or 'bot' in ctx.channel.name
+        if (is_bot_channel):
+            public = True
 
         group_truncated = {}
 
@@ -76,7 +84,7 @@ class RanksCommand(commands.Cog):
                               ' represent performance at university_',
                         inline=False)
 
-        await ctx.send(embed=embed)
+        await ctx.send(embed=embed, hidden=not public)
 
 
 def setup(bot):

--- a/commands/ranks_command.py
+++ b/commands/ranks_command.py
@@ -41,7 +41,7 @@ class RanksCommand(commands.Cog):
             grouped_ranks = await ranks.get_top_ranks(year)
 
         is_bot_channel = not ctx.guild or 'bot' in ctx.channel.name
-        if (is_bot_channel):
+        if is_bot_channel:
             public = True
 
         group_truncated = {}

--- a/handlers/role_notification_handler.py
+++ b/handlers/role_notification_handler.py
@@ -1,8 +1,7 @@
 import discord
 from discord.ext import commands
 from helpers import role_helper
-import time
-
+import asyncio
 
 class RoleNotificationHandler(commands.Cog):
     def __init__(self, bot):
@@ -18,7 +17,7 @@ class RoleNotificationHandler(commands.Cog):
                                                          'related to your university and programme, so you should get '
                                                          'them by going to the <#879407265336152104> channel '
                                                          'and clicking the corresponding buttons._')
-            time.sleep(60)
+            await asyncio.sleep(60)
             await msg.delete()
 
 def setup(bot):

--- a/handlers/role_notification_handler.py
+++ b/handlers/role_notification_handler.py
@@ -1,6 +1,7 @@
 import discord
 from discord.ext import commands
 from helpers import role_helper
+import time
 
 
 class RoleNotificationHandler(commands.Cog):
@@ -13,11 +14,12 @@ class RoleNotificationHandler(commands.Cog):
             return
 
         if await role_helper.should_be_notified(message.author):
-            await message.reply(message.author.mention + ' _You don\'t have roles! Roles unlock hidden channels '
+            msg = await message.reply(message.author.mention + ' _You don\'t have roles! Roles unlock hidden channels '
                                                          'related to your university and programme, so you should get '
                                                          'them by going to the <#879407265336152104> channel '
                                                          'and clicking the corresponding buttons._')
-
+            time.sleep(60)
+            await msg.delete()
 
 def setup(bot):
     bot.add_cog(RoleNotificationHandler(bot))


### PR DESCRIPTION
Closes #96 
The three most 'cluttering' commands now contain a 'public' parameter which is false by default and determines if the output of the command should be visible to everyone or just the sender. The role notification disappears after a minute.
**Should be tested with an actual bot-spam channel as I don't have one!**